### PR TITLE
Prevent empty Kirki::$fields by adding fields to it

### DIFF
--- a/src/Kirki.php
+++ b/src/Kirki.php
@@ -183,6 +183,7 @@ class Kirki extends Init {
 		$args = wp_parse_args( $args, $config );
 
 		if ( class_exists( $classname ) ) {
+			self::$fields[] = $args;
 			new $classname( $args );
 			return;
 		}


### PR DESCRIPTION
This is a fix/suggestion related to: https://github.com/kirki-framework/field-typography/issues/2

Currently the global variable `Kirki::$fields` stays empty as single control packages (e.g. `kirki-framework/control-select`) do not add the `$args` to it. 

As the usage of `Kirki/Compatibility` package seems to be optional, I guess this is a good position to keep it seperated, valid for all fields as it adds a field to the global variable if a separated class exists for the field/control type. 

Best regards!